### PR TITLE
set default themes

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2,7 +2,7 @@
 
 @plugin 'daisyui' {
 	themes:
-		all;
-	/* caramellatte --default, */
-	/* coffee --prefersdark; */
+		/* all; */
+		caramellatte --default,
+		coffee --prefersdark;
 }


### PR DESCRIPTION
despite having the theme provider that sets the correct theme, not having a default theme set in daisyUI's config can cause a different default theme to show briefly, causing a visual flicker.